### PR TITLE
Restore navbar/modal/tooltip with bootstrap-vue-next (stage 2)

### DIFF
--- a/anthonyhatch.com/package-lock.json
+++ b/anthonyhatch.com/package-lock.json
@@ -14,6 +14,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@fortawesome/vue-fontawesome": "^3.0.8",
         "bootstrap": "^5.3.3",
+        "bootstrap-vue-next": "^0.45.8",
         "express": "^4.19.2",
         "serve-static": "^1.15.0",
         "vue": "^3.5.13",
@@ -516,6 +517,68 @@
         "node": ">=18"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
+    "node_modules/@floating-ui/vue": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.1.11.tgz",
+      "integrity": "sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6",
+        "@floating-ui/utils": "^0.2.11",
+        "vue-demi": ">=0.13.0"
+      }
+    },
+    "node_modules/@floating-ui/vue/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "6.7.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
@@ -569,6 +632,24 @@
       "peerDependencies": {
         "@fortawesome/fontawesome-svg-core": "~1 || ~6 || ~7",
         "vue": ">= 3.0.0 < 4"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
+      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1248,6 +1329,41 @@
         "win32"
       ]
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.4.tgz",
+      "integrity": "sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/vue-virtual": {
+      "version": "3.13.32",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.32.tgz",
+      "integrity": "sha512-E8OCutx7QnwZdvpJijz0Q2PHsYDWBWjnGr3TvgWiqxTU35jB1kVhtkd93scRV7tTFuId2tg3x2iFiw+IE4evjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.0 || ^3.0.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1264,6 +1380,12 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
@@ -1450,6 +1572,44 @@
       "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
       "license": "MIT"
     },
+    "node_modules/@vueuse/core": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
+      "integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "14.3.0",
+        "@vueuse/shared": "14.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
+      "integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.3.0.tgz",
+      "integrity": "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1469,6 +1629,18 @@
       "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -1524,6 +1696,56 @@
       "license": "MIT",
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
+      }
+    },
+    "node_modules/bootstrap-vue-next": {
+      "version": "0.45.8",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue-next/-/bootstrap-vue-next-0.45.8.tgz",
+      "integrity": "sha512-D4Lntb6z7cVttLrOYCUy7joCZMYnl6lkKbOFJSxHKc0pNFsnduvp9PQs47FQwPWyq5HxTk3twcsyRdB0eWDAoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/vue": "^1.1.11",
+        "@vueuse/core": "^14.2.1",
+        "reka-ui": "^2.9.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bootstrap-vue-next"
+      },
+      "peerDependencies": {
+        "@floating-ui/vue": "*",
+        "@internationalized/date": "*",
+        "@vueuse/core": "*",
+        "@vueuse/integrations": "*",
+        "bootstrap": "^5.3.0",
+        "focus-trap": "*",
+        "reka-ui": "*",
+        "vue": "^3.5.13",
+        "vue-router": "*"
+      },
+      "peerDependenciesMeta": {
+        "@floating-ui/vue": {
+          "optional": true
+        },
+        "@internationalized/date": {
+          "optional": true
+        },
+        "@vueuse/core": {
+          "optional": true
+        },
+        "@vueuse/integrations": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "reka-ui": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/brace-expansion": {
@@ -1647,6 +1869,12 @@
       "dependencies": {
         "ms": "2.0.0"
       }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -2252,6 +2480,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -2398,6 +2632,31 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/reka-ui": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.10.1.tgz",
+      "integrity": "sha512-drcOQ4rQtDYAcGCsyQBqQg8QQ+H3B+zDaMJU0h8KPEPMa7g9BHu3zcOi4OB39XJSWizceFoNO0Z9tctSGLOXqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.13",
+        "@floating-ui/vue": "^1.1.6",
+        "@internationalized/date": "^3.5.0",
+        "@internationalized/number": "^3.5.0",
+        "@tanstack/vue-virtual": "^3.12.0",
+        "@vueuse/core": "^14.1.0",
+        "@vueuse/shared": "^14.1.0",
+        "aria-hidden": "^1.2.4",
+        "defu": "^6.1.5",
+        "ohash": "^2.0.11"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/zernonia"
+      },
+      "peerDependencies": {
+        "vue": ">= 3.4.0"
       }
     },
     "node_modules/rollup": {
@@ -2658,6 +2917,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/anthonyhatch.com/package.json
+++ b/anthonyhatch.com/package.json
@@ -17,6 +17,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@fortawesome/vue-fontawesome": "^3.0.8",
     "bootstrap": "^5.3.3",
+    "bootstrap-vue-next": "^0.45.8",
     "express": "^4.19.2",
     "serve-static": "^1.15.0",
     "vue": "^3.5.13",

--- a/anthonyhatch.com/src/App.vue
+++ b/anthonyhatch.com/src/App.vue
@@ -1,42 +1,22 @@
 <template>
   <div id="app">
     <div class="container">
-      <!-- TODO(stage 2): restore bootstrap-vue-next navbar collapse + Books modal -->
-      <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
-        <div class="container-fluid">
-          <button
-            class="navbar-toggler"
-            type="button"
-            data-bs-toggle="collapse"
-            data-bs-target="#nav_text_collapse"
-          >
-            <span class="navbar-toggler-icon"></span>
-          </button>
-          <div id="nav_text_collapse" class="collapse navbar-collapse">
-            <ul class="navbar-nav">
-              <li class="nav-item">
-                <router-link class="nav-link" to="/"><font-awesome-icon icon="user" /> Home</router-link>
-              </li>
-              <li class="nav-item">
-                <router-link class="nav-link" to="/the_codes"><font-awesome-icon icon="laptop-code" /> Skills</router-link>
-              </li>
-              <li class="nav-item">
-                <router-link class="nav-link" to="/about"><font-awesome-icon icon="address-card" /> About</router-link>
-              </li>
-              <li class="nav-item">
-                <button class="btn btn-link nav-link" @click="showBooks = !showBooks">
-                  <font-awesome-icon icon="book" /> books
-                </button>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </nav>
-
-      <!-- Temporary inline books panel until modal is restored in stage 2 -->
-      <div v-if="showBooks" class="container my-3">
-        <Books />
-      </div>
+      <BNavbar toggleable="lg" type="light" variant="light" sticky="top">
+        <BNavbarToggle target="nav_text_collapse" />
+        <BCollapse id="nav_text_collapse" is-nav>
+          <BNavbarNav>
+            <BNavItem to="/"><font-awesome-icon icon="user" /> Home</BNavItem>
+            <BNavItem to="/the_codes"><font-awesome-icon icon="laptop-code" /> Skills</BNavItem>
+            <BNavItem to="/about"><font-awesome-icon icon="address-card" /> About</BNavItem>
+            <BButton style="padding: 0;" variant="link" @click="showBooks = true">
+              <font-awesome-icon icon="book" /> books
+            </BButton>
+            <BModal v-model="showBooks" title="books" no-footer>
+              <Books />
+            </BModal>
+          </BNavbarNav>
+        </BCollapse>
+      </BNavbar>
 
       <div class="container">
         <div class="row">
@@ -51,6 +31,15 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
+import {
+  BNavbar,
+  BNavbarToggle,
+  BNavbarNav,
+  BNavItem,
+  BCollapse,
+  BButton,
+  BModal,
+} from 'bootstrap-vue-next'
 import Books from '@/components/Books.vue'
 
 const showBooks = ref(false)

--- a/anthonyhatch.com/src/components/Skills.vue
+++ b/anthonyhatch.com/src/components/Skills.vue
@@ -7,7 +7,7 @@
 
             <div class="row">
                 <div class="col-2" v-for="img in skill.images" :key="img.title">
-                    <img class="max_logo_height img-fluid" :src="img.url" :alt="img.title" :title="img.title"/>
+                    <img class="max_logo_height img-fluid" :src="img.url" :alt="img.title" v-b-tooltip.hover :title="img.title"/>
                 </div>
             </div>
         </div>
@@ -15,6 +15,7 @@
 </template>
 
 <script setup lang="ts">
+import { vBTooltip } from 'bootstrap-vue-next'
 import type { SkillGroup } from '@/models/SkillGroup'
 
 defineProps<{ skill: SkillGroup }>()

--- a/anthonyhatch.com/src/main.ts
+++ b/anthonyhatch.com/src/main.ts
@@ -1,8 +1,9 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
+import { createBootstrap } from 'bootstrap-vue-next'
 import 'bootstrap/dist/css/bootstrap.css'
-import 'bootstrap/dist/js/bootstrap.bundle.min.js'
+import 'bootstrap-vue-next/dist/bootstrap-vue-next.css'
 import './assets/css/main.css'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faCoffee, faAddressCard, faBook, faBuilding, faLaptopCode, faUser } from '@fortawesome/free-solid-svg-icons'
@@ -14,4 +15,5 @@ library.add(faCoffee, faBook, faAddressCard, faGithub, faLinkedin, faStackOverfl
 const app = createApp(App)
 app.component('font-awesome-icon', FontAwesomeIcon)
 app.use(router)
+app.use(createBootstrap())
 app.mount('#app')

--- a/anthonyhatch.com/tsconfig.json
+++ b/anthonyhatch.com/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
+    "skipLibCheck": true,
     "jsx": "preserve",
     "importHelpers": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
Stage 2 of the Vue 2 to Vue 3 migration. Replaces the temporary Bootstrap 5 stubs from stage 1 with real **bootstrap-vue-next** components now that we are on Vue 3.

> Stacked on #15 (stage 1). Base branch is `migrate/vue3-vite`; retarget to `develop` once stage 1 merges.

## Changes
- Add **bootstrap-vue-next 0.45** + its CSS; register `createBootstrap()` (orchestrator for modal/tooltip)
- **App.vue:** restore `BNavbar`/`BNavbarToggle`/`BCollapse`/`BNavbarNav`/`BNavItem` and the Books `BModal` (`v-model`-driven, `no-footer` to drop OK/Cancel buttons)
- **Skills.vue:** restore `v-b-tooltip` on skill logos
- Import components/directive locally where used (tree-shakeable)
- Remove temporary Bootstrap JS bundle import
- Add `skipLibCheck` to tsconfig (bootstrap-vue-next `.d.ts` otherwise fails `vue-tsc`)

## Verification
- `npm run build` (vue-tsc + Vite) passes
- Verified navbar collapse, Books modal, and skill tooltips in the browser
